### PR TITLE
Fix for tf display not loading frame config

### DIFF
--- a/src/rviz/default_plugin/tf_display.h
+++ b/src/rviz/default_plugin/tf_display.h
@@ -73,6 +73,7 @@ public:
 protected:
   // Overrides from Display
   virtual void onInitialize();
+  virtual void load(const Config& config);
   virtual void fixedFrameChanged();
   virtual void reset();
 
@@ -103,6 +104,9 @@ private:
 
   typedef std::map<std::string, FrameInfo*> M_FrameInfo;
   M_FrameInfo frames_;
+
+  typedef std::map<std::string, bool> M_EnabledState;
+  M_EnabledState frame_config_enabled_state_;
 
   float update_timer_;
 


### PR DESCRIPTION
Fixing issue with the tf display where the enabled status was not properly read from the config file. Updated the display to read the value, store the values in a map, and use the map to update the enabled/disabled state of the frame once the frame is added. This properly handles frames which are not published at the time the tf display is created.