### PR TITLE
Updated the marker display and tf plugins to not reset enabled namespaces/frames

### DIFF
--- a/src/rviz/default_plugin/marker_display.cpp
+++ b/src/rviz/default_plugin/marker_display.cpp
@@ -123,7 +123,6 @@ void MarkerDisplay::clearMarkers()
   tf_filter_->clear();
   namespaces_category_->removeChildren();
   namespaces_.clear();
-  namespace_config_enabled_state_.clear();
 }
 
 void MarkerDisplay::onEnable()
@@ -533,6 +532,9 @@ void MarkerNamespace::onEnableChanged()
   {
     owner_->deleteMarkersInNamespace( getName().toStdString() );
   }
+
+  // Update the configuration that stores the enabled state of all markers
+  owner_->namespace_config_enabled_state_[getName()] = isEnabled();
 }
 
 } // namespace rviz

--- a/src/rviz/default_plugin/tf_display.cpp
+++ b/src/rviz/default_plugin/tf_display.cpp
@@ -260,7 +260,6 @@ void TFDisplay::clear()
   }
 
   frames_.clear();
-  frame_config_enabled_state_.clear();
 
   update_timer_ = 0.0f;
 
@@ -781,6 +780,9 @@ void FrameInfo::setEnabled( bool enabled )
     display_->all_enabled_property_->setBool( false );
     display_->changing_single_frame_enabled_state_ = false;
   }
+
+  // Update the configuration that stores the enabled state of all frames
+  display_->frame_config_enabled_state_[this->name_] = enabled;
 
   display_->context_->queueRender();
 }


### PR DESCRIPTION
Updated the marker display and tf plugins to update the map of enabled namespaces and frames whenever those frames are enabled/disabled using the check boxes. Also updated the plugins so that the map of enabled namespaces and frames does not get erased whenever the plugin is reset. (#988)

This allows the currently selected namespaces/frames to remain selected after the Reset button is pressed.